### PR TITLE
Makes the username configurable via settings & small tweaks to method args

### DIFF
--- a/lti_tool/auth/middleware.py
+++ b/lti_tool/auth/middleware.py
@@ -93,7 +93,10 @@ class LtiLaunchAuthenticationMiddleware:
                 " before the LtiLaunchAuthenticationMiddleware class."
             )
         try:
-            username = request.lti_launch.user.sub
+            if hasattr(settings, 'LTI_TOOL') and settings.LTI_TOOL.get("use_person_sourcedid", False):
+                username = request.lti_launch.get_claim("https://purl.imsglobal.org/spec/lti/claim/lis").get("person_sourcedid")
+            else:
+                username = request.lti_launch.user.sub
         except AttributeError:
             # If the LTI launch user doesn't exist then remove any existing
             # authenticated remote-user, or return (leaving request.user set to


### PR DESCRIPTION
Fixes a couple of args in methods that were expecting 2 positional arguments but were only receiving 1.

Adds support for an optional LTI_TOOL settings object that can have a `use_person_sourcedid` boolean.
If present and True, use the SIS ID of the user as the username otherwise the users sub value will be used.